### PR TITLE
ParseMusicXML: Onbekende instrumenten oplossing

### DIFF
--- a/src/main/java/nl/rollingsticks/domain/parsemusicxml/Instrument.java
+++ b/src/main/java/nl/rollingsticks/domain/parsemusicxml/Instrument.java
@@ -5,11 +5,15 @@ class Instrument {
 		this(nootNaam, "");
 	}
 	Instrument (String nootNaam, String instrumentNaam) {
+		this(nootNaam, instrumentNaam, "");
+	}
+	Instrument (String nootNaam, String instrumentNaam, String instrumentId) {
 		this.nootNaam = nootNaam;
 		this.instrumentNaam = instrumentNaam;
+		this.instrumentId = instrumentId;
 	}
 	
 	String nootNaam;
-	String instrumentId;
 	String instrumentNaam;
+	String instrumentId;
 }

--- a/src/main/java/nl/rollingsticks/domain/parsemusicxml/ParseMusicXML.java
+++ b/src/main/java/nl/rollingsticks/domain/parsemusicxml/ParseMusicXML.java
@@ -329,7 +329,10 @@ public class ParseMusicXML {
 				return; // niet langer doorgaan dan nodig is.
 			}
 		}
+		// Instrument onbekend, maar wordt wel toegevoegd. Alleen de koppeling naar de naam v/d noot kan niet worden gelegd.
 		System.out.println("**** Probleem: onbekend muziekinstrument - " + instrumentIndexId + " - [" + instrumentIndexNaam + "]");
+		System.out.println(" -> Combi toevoegen aan index instrumenten, naam v/d noot wordt onbekend.");
+		instrumenten.add(new Instrument("onbekend", instrumentIndexNaam, instrumentIndexId));
 	}
 	
 	private Instrument opzoekenInstrument (String instrumentId) {


### PR DESCRIPTION
Onbekende instrumenten worden wel netjes gekoppeld. Naam van de noot is dan 'onbekend'.